### PR TITLE
Fix clippy warnings in examples.

### DIFF
--- a/examples/queens/src/main.rs
+++ b/examples/queens/src/main.rs
@@ -18,24 +18,24 @@ struct Queens {
 }
 
 // Chech one straight line in one specific direction
-fn one_trace(board: &Vec<u8>, row: usize, col: usize, dy: i8, dx: i8) -> u8 {
+fn one_trace(board: &[u8], row: usize, col: usize, dy: i8, dx: i8) -> u8 {
     let mut num_of_collisions = 0;
     let mut x: i16 = col as i16;
     let mut y: i16 = row as i16;
 
     loop {
-        x = x + dx as i16;
+        x += dx as i16;
         if (x < 0) || (x > 7) {
             break;
         }
 
-        y = y + dy as i16;
+        y += dy as i16;
         if (y < 0) || (y > 7) {
             break;
         }
 
         if board[((y * 8) + x) as usize] == 1 {
-            num_of_collisions = num_of_collisions + 1;
+            num_of_collisions += 1;
         }
     }
 
@@ -43,32 +43,32 @@ fn one_trace(board: &Vec<u8>, row: usize, col: usize, dy: i8, dx: i8) -> u8 {
 }
 
 // Check all eight directions:
-fn find_collisions(board: &Vec<u8>, row: usize, col: usize) -> u8 {
+fn find_collisions(board: &[u8], row: usize, col: usize) -> u8 {
     let mut num_of_collisions = 0;
 
     // up
-    num_of_collisions = num_of_collisions + one_trace(board, row, col, -1, 0);
+    num_of_collisions += one_trace(board, row, col, -1, 0);
 
     // up right
-    num_of_collisions = num_of_collisions + one_trace(board, row, col, -1, 1);
+    num_of_collisions += one_trace(board, row, col, -1, 1);
 
     // right
-    num_of_collisions = num_of_collisions + one_trace(board, row, col, 0, 1);
+    num_of_collisions += one_trace(board, row, col, 0, 1);
 
     // right down
-    num_of_collisions = num_of_collisions + one_trace(board, row, col, 1, 1);
+    num_of_collisions += one_trace(board, row, col, 1, 1);
 
     // down
-    num_of_collisions = num_of_collisions + one_trace(board, row, col, 1, 0);
+    num_of_collisions += one_trace(board, row, col, 1, 0);
 
     // down left
-    num_of_collisions = num_of_collisions + one_trace(board, row, col, 1, -1);
+    num_of_collisions += one_trace(board, row, col, 1, -1);
 
     // left
-    num_of_collisions = num_of_collisions + one_trace(board, row, col, 0, -1);
+    num_of_collisions += one_trace(board, row, col, 0, -1);
 
     // left top
-    num_of_collisions = num_of_collisions + one_trace(board, row, col, -1, -1);
+    num_of_collisions += one_trace(board, row, col, -1, -1);
 
     num_of_collisions
 }
@@ -120,7 +120,7 @@ impl Individual for Queens {
             for col in 0..8 {
                 // Found a queen, so check for collisions
                 if self.board[(row * 8) + col] == 1 {
-                    num_of_collisions = num_of_collisions + find_collisions(&self.board, row, col);
+                    num_of_collisions += find_collisions(&self.board, row, col);
                 }
             }
         }

--- a/examples/sudoku/src/main.rs
+++ b/examples/sudoku/src/main.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 use darwin_rs::{Individual, SimulationBuilder, Error};
 
 // A cell is a 3x3 sub field inside the 9x9 sudoku field
-fn fitness_of_one_cell(sudoku: &Vec<u8>, row: usize, col: usize) -> f64 {
+fn fitness_of_one_cell(sudoku: &[u8], row: usize, col: usize) -> f64 {
     let mut number_occurence = vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
     let mut error = 0.0;
 
@@ -22,62 +22,62 @@ fn fitness_of_one_cell(sudoku: &Vec<u8>, row: usize, col: usize) -> f64 {
             let data = sudoku[(((row + i) * 9) + col + j) as usize];
 
             if data > 0 && data < 10 {
-                number_occurence[(data - 1) as usize] = number_occurence[(data - 1) as usize] + 1;
+                number_occurence[(data - 1) as usize] += 1;
             } else {
-                error = error + 1.0;
+                error += 1.0;
             }
         }
     }
 
     for number in number_occurence {
         if number != 1 {
-            error = error + 1.0;
+            error += 1.0;
         }
     }
 
     error
 }
 
-fn fitness_of_one_row(sudoku: &Vec<u8>, row: usize) -> f64 {
+fn fitness_of_one_row(sudoku: &[u8], row: usize) -> f64 {
     let mut number_occurence = vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
     let mut error = 0.0;
 
     for col in 0..9 {
         let number = sudoku[(row * 9) + col];
         if number > 0 && number < 10 {
-            number_occurence[(number - 1) as usize] = number_occurence[(number - 1) as usize] + 1;
+            number_occurence[(number - 1) as usize] += 1;
         } else {
-            error = error + 1.0;
+            error += 1.0;
         }
     }
 
     // Each number must be unique, otherwise increase error
     for number in number_occurence {
         if number != 1 {
-            error = error + 1.0;
+            error += 1.0;
         }
     }
 
     error
 }
 
-fn fitness_of_one_col(sudoku: &Vec<u8>, col: usize) -> f64 {
+fn fitness_of_one_col(sudoku: &[u8], col: usize) -> f64 {
     let mut number_occurence = vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
     let mut error = 0.0;
 
     for row in 0..9 {
         let number = sudoku[(row * 9) + col];
         if number > 0 && number < 10 {
-            number_occurence[(number - 1) as usize] = number_occurence[(number - 1) as usize] + 1;
+            number_occurence[(number - 1) as usize] += 1;
         } else {
-            error = error + 1.0;
+            error += 1.0;
         }
     }
 
     // Each number must be unique, otherwise increase error
     for number in number_occurence {
         if number != 1 {
-            error = error + 1.0;
+            error += 1.0;
         }
     }
 
@@ -126,8 +126,8 @@ impl Individual for Sudoku {
         let mut result = 0.0;
 
         for i in 0..9 {
-            result = result + fitness_of_one_row(&self.solved, i);
-            result = result + fitness_of_one_col(&self.solved, i);
+            result += fitness_of_one_row(&self.solved, i);
+            result += fitness_of_one_col(&self.solved, i);
         }
 
 
@@ -135,12 +135,12 @@ impl Individual for Sudoku {
         let mut j = 0;
 
         loop {
-            result = result + fitness_of_one_cell(&self.solved, i, j);
+            result += fitness_of_one_cell(&self.solved, i, j);
 
-            i = i + 3;
+            i += 3;
             if i >= 9 {
                 i = 0;
-                j = j + 3;
+                j += 3;
                 if j >= 9 {
                     break;
                 }

--- a/examples/tsp/src/main.rs
+++ b/examples/tsp/src/main.rs
@@ -15,7 +15,7 @@ use rand::Rng;
 // Internal modules
 use darwin_rs::{Individual, SimulationBuilder, Error};
 
-fn city_distance(city: &Vec<(f64, f64)>, index1: usize, index2: usize) -> f64 {
+fn city_distance(city: &[(f64, f64)], index1: usize, index2: usize) -> f64 {
     let (x1, y1) = city[index1];
     let (x2, y2) = city[index2];
     let x = x2 - x1;
@@ -86,7 +86,7 @@ impl Individual for CityItem {
         let mut length: f64 = 0.0;
 
         for index in &self.path {
-            length = length + city_distance(&self.city_positions, *prev_index, *index);
+            length += city_distance(&self.city_positions, *prev_index, *index);
 
             prev_index = index;
         }
@@ -124,7 +124,7 @@ fn main() {
             println!("Path and coordinates: ");
 
             let cities = &tsp_simulation.population[0].individual.city_positions;
-            for index in tsp_simulation.population[0].individual.path.iter() {
+            for index in &tsp_simulation.population[0].individual.path {
                 let (x, y) = cities[*index];
                 println!("{} {}", x, y);
             }

--- a/examples/tsp2/src/main.rs
+++ b/examples/tsp2/src/main.rs
@@ -15,7 +15,7 @@ use rand::Rng;
 // Internal modules
 use darwin_rs::{Individual, SimulationBuilder, Error};
 
-fn city_distance(city: &Vec<(f64, f64)>, index1: usize, index2: usize) -> f64 {
+fn city_distance(city: &[(f64, f64)], index1: usize, index2: usize) -> f64 {
     let (x1, y1) = city[index1];
     let (x2, y2) = city[index2];
     let x = x2 - x1;
@@ -108,7 +108,7 @@ impl Individual for CityItem {
         let mut length: f64 = 0.0;
 
         for index in &self.path {
-            length = length + city_distance(&self.city_positions, *prev_index, *index);
+            length += city_distance(&self.city_positions, *prev_index, *index);
 
             prev_index = index;
         }
@@ -142,7 +142,7 @@ fn main() {
             println!("Path and coordinates: ");
 
             let cities = &tsp_simulation.population[0].individual.city_positions;
-            for index in tsp_simulation.population[0].individual.path.iter() {
+            for index in &tsp_simulation.population[0].individual.path {
                 let (x, y) = cities[*index];
                 println!("{} {}", x, y);
             }


### PR DESCRIPTION
This fixes clippy warnings for all examples except the ocr example (I can't compile the ocr example because I have incompatible versions of native libfreetype and libpng libraries on my machine).

I did separate commits for each example for the sake of better review, I can squash them if you want.
